### PR TITLE
Rename Authorization header to 'Authorization'

### DIFF
--- a/headers.go
+++ b/headers.go
@@ -50,7 +50,7 @@ The WWW-Authenticate header is sent along with a 401 Unauthorized response.
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate`,
 	},
 	{
-		Name:    "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization",
+		Name:    "Authorization",
 		Summary: "Contains the credentials to authenticate a user-agent with a server.",
 		Description: `The HTTP Authorization request header contains the credentials to authenticate a user agent with a server, usually after the server has responded with a 401 Unauthorized status and the WWW-Authenticate header.
 


### PR DESCRIPTION
# Description

Rename Authorization header to 'Authorization'. Previously this was set to the Mozilla docs url.

Fixes # https://github.com/dnnrly/httpref/issues/11

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Running existing tests
- [ ] Created new tests

# Checklist:

- [ ] My code has been linted (`make lint`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have rebased my branch to include the latest changes from `master`
