### PR TITLE
Remove unused structs in test

### DIFF
--- a/httpref_test.go
+++ b/httpref_test.go
@@ -9,9 +9,6 @@ import (
 
 func TestReferences_ByName(t *testing.T) {
 	Statuses = append(Statuses, Reference{Name: "501-extended"})
-	type args struct {
-		code string
-	}
 	tests := []struct {
 		name string
 		want int
@@ -32,9 +29,6 @@ func TestReferences_ByName(t *testing.T) {
 }
 
 func TestReferences_InRange(t *testing.T) {
-	type args struct {
-		code string
-	}
 	tests := []string{
 		"19150",
 		"16406",


### PR DESCRIPTION
# Description

Removes some lintern errors.

```make lint
golangci-lint run
WARN [runner] Can't run linter goanalysis_metalinter: assign: failed prerequisites: inspect@github.com/dnnrly/httpref/cmd
httpref_test.go:12:7: type `args` is unused (unused)
	type args struct {
	     ^
httpref_test.go:35:7: type `args` is unused (unused)
	type args struct {
	     ^
make: *** [lint] Error 1
```

Haven't opened an issue because the diff is trivial — may do in the future if considered necessary.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Running existing tests

```
make test
go test -json ./... | tparse -all

+--------+---------+---------------------------------------------+---------+
| STATUS | ELAPSED |                    TEST                     | PACKAGE |
+--------+---------+---------------------------------------------+---------+
| PASS   |    0.00 | TestReferences_ByName                       | httpref |
| PASS   |    0.00 | TestReferences_ByName/1                     | httpref |
| PASS   |    0.00 | TestReferences_ByName/40                    | httpref |
| PASS   |    0.00 | TestReferences_ByName/501                   | httpref |
| PASS   |    0.00 | TestReferences_ByName/501*                  | httpref |
| PASS   |    0.00 | TestReferences_InRange                      | httpref |
| PASS   |    0.00 | TestReferences_InRange/19150                | httpref |
| PASS   |    0.00 | TestReferences_InRange/16406                | httpref |
| PASS   |    0.00 | TestReferences_InRange/5988                 | httpref |
| PASS   |    0.00 | TestReferences_InRange/5989                 | httpref |
| PASS   |    0.00 | TestReference_SummarizeContainsCorrectParts | httpref |
| PASS   |    0.00 | TestReference_SummarizeLimitsLineLength     | httpref |
| PASS   |    0.00 | TestReference_DescribeLimitsLength          | httpref |
| PASS   |    0.00 | TestReferences_Titles                       | httpref |
+--------+---------+---------------------------------------------+---------+

+--------+----------+---------------------------+-------+------+------+------+
| STATUS | ELAPSED  |          PACKAGE          | COVER | PASS | FAIL | SKIP |
+--------+----------+---------------------------+-------+------+------+------+
| PASS   | (cached) | github.com/dnnrly/httpref | 0.0%  |   14 |    0 |    0 |
+--------+----------+---------------------------+-------+------+------+------+
```

# Checklist:

- [x] My code has been linted (`make lint`)
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch to include the latest changes from `master`
