### PR TITLE
Add 599 HTTP Status Code

### DIFF
--- a/httpref_test.go
+++ b/httpref_test.go
@@ -18,6 +18,7 @@ func TestReferences_ByName(t *testing.T) {
 		{name: "40", want: 10},
 		{name: "501", want: 1},
 		{name: "501*", want: 2},
+		{name: "599", want: 1},
 	}
 
 	for _, tt := range tests {

--- a/statuses.go
+++ b/statuses.go
@@ -600,4 +600,13 @@ Network operators sometimes require some authentication, acceptance of terms, or
 
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/511`,
 	},
+	{
+		Name:    "599",
+		Summary: "Network Connect Timeout Error",
+		Description: `The HTTP 599 Network Connect Timeout Error response status code signals a network connect timeout behind the proxy to a client in front of the proxy.
+
+This status code is not specified in any RFCs, but is used by some HTTP proxies to signal a network connect timeout behind the proxy to a client in front of the proxy.
+
+https://httpstatus.in/599/`,
+	},
 }


### PR DESCRIPTION
# Description

This pull request adds an http status entry for status code `599` as documented here https://httpstatus.in/599/.

Fixes https://github.com/dnnrly/httpref/issues/33

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Running existing tests
- [x] Created new tests

The following commands were also run to verify functionality
```
./bin/httpref 599
./bin/httpref status 599
./bin/httpref statuses 599
```

# Checklist:

- [x] My code has been linted (`make lint`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have rebased my branch to include the latest changes from `master`
